### PR TITLE
Fcom 312

### DIFF
--- a/Frends.Community.Oracle/Definitions.cs
+++ b/Frends.Community.Oracle/Definitions.cs
@@ -229,7 +229,7 @@ namespace Frends.Community.Oracle
         public int MaxmimumRows { get; set; }
 
         /// <summary>
-        /// Overwrite decimal value separator char. If empty, uses Oracle default.
+        /// Overwrite decimal value separator in Decimal type columns. If empty, uses Oracle default.
         /// </summary>
         [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]
@@ -266,7 +266,7 @@ namespace Frends.Community.Oracle
         public string CsvSeparator { get; set; }
 
         /// <summary>
-        /// Overwrite decimal value separator char. If empty, uses Oracle default.
+        /// Overwrite decimal value separator in Decimal type columns. If empty, uses Oracle default.
         /// </summary>
         [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue("")]

--- a/Frends.Community.Oracle/Definitions.cs
+++ b/Frends.Community.Oracle/Definitions.cs
@@ -227,6 +227,13 @@ namespace Frends.Community.Oracle
         /// </summary>
         [DefaultValue(-1)]
         public int MaxmimumRows { get; set; }
+
+        /// <summary>
+        /// Overwrite decimal value separator char. If empty, uses Oracle default.
+        /// </summary>
+        [DisplayFormat(DataFormatString = "Text")]
+        [DefaultValue("")]
+        public string DecimalSeparator { get; set; }
     }
 
     /// <summary>
@@ -257,6 +264,13 @@ namespace Frends.Community.Oracle
         [DisplayFormat(DataFormatString = "Text")]
         [DefaultValue(";")]
         public string CsvSeparator { get; set; }
+
+        /// <summary>
+        /// Overwrite decimal value separator char. If empty, uses Oracle default.
+        /// </summary>
+        [DisplayFormat(DataFormatString = "Text")]
+        [DefaultValue("")]
+        public string DecimalSeparator { get; set; }
     }
 
     /// <summary>

--- a/Frends.Community.Oracle/Frends.Community.Oracle.csproj
+++ b/Frends.Community.Oracle/Frends.Community.Oracle.csproj
@@ -11,7 +11,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.1.1</Version>
+    <Version>3.1.2</Version>
 
   </PropertyGroup>
 

--- a/Frends.Community.Oracle/Frends.Community.Oracle.csproj
+++ b/Frends.Community.Oracle/Frends.Community.Oracle.csproj
@@ -11,7 +11,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.1.2</Version>
+    <Version>3.2.0</Version>
 
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Executes a single query to Oracle database.
 | Output to file | `bool` | If true, write output to file, instead returning it. | `true` |
 | Path | `bool` | Path where file is written. | `c:\temp\queryOutput.xml` |
 | Encoding | `bool` | Set encoding of file. | `utf-8` |
-| DecimalSeparator | `string` | If set, overwrites default decimal separator with given value | `.` |
+| DecimalSeparator | `string` | If set, overwrites default decimal separator in Oracle Decimal type fields with given value | `.` |
 
 
 #### Json Output
@@ -76,7 +76,7 @@ Executes a single query to Oracle database.
 | Output to file | `bool` | If true, write output to file, instead returning it. | `true` |
 | Path | `bool` | Path where file is written. | `c:\temp\queryOutput.xml` |
 | Encoding | `bool` | Set encoding of file. | `utf-8` |
-| DecimalSeparator | `string` | If set, overwrites default decimal separator with given value | `.` |
+| DecimalSeparator | `string` | If set, overwrites default decimal separator in Oracle Decimal type fields with given value | `.` |
 
 
 #### Output File
@@ -262,4 +262,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 3.0.0 | Query ranamed and namespace changed to more generic to enable adding new task. Added BatchOperationOracle task. |
 | 3.1.0 | Multiquery tasks added. |
 | 3.1.1 | Connection string fields changed from text fields to password fields now hidden and won't show on logs. Revised README, Detailed logging enabled to TransactionalMultiQuery. |
-| 3.1.2 | Added possibility to overwrite default decimal separator when using CSV or XML output. |
+| 3.2.0 | Added possibility to overwrite default decimal separator in Decimal typed columns, when using CSV or XML output. |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Executes a single query to Oracle database.
 | Output to file | `bool` | If true, write output to file, instead returning it. | `true` |
 | Path | `bool` | Path where file is written. | `c:\temp\queryOutput.xml` |
 | Encoding | `bool` | Set encoding of file. | `utf-8` |
+| DecimalSeparator | `string` | If set, overwrites default decimal separator with given value | `.` |
 
 
 #### Json Output
@@ -75,6 +76,7 @@ Executes a single query to Oracle database.
 | Output to file | `bool` | If true, write output to file, instead returning it. | `true` |
 | Path | `bool` | Path where file is written. | `c:\temp\queryOutput.xml` |
 | Encoding | `bool` | Set encoding of file. | `utf-8` |
+| DecimalSeparator | `string` | If set, overwrites default decimal separator with given value | `.` |
 
 
 #### Output File
@@ -260,3 +262,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 3.0.0 | Query ranamed and namespace changed to more generic to enable adding new task. Added BatchOperationOracle task. |
 | 3.1.0 | Multiquery tasks added. |
 | 3.1.1 | Connection string fields changed from text fields to password fields now hidden and won't show on logs. Revised README, Detailed logging enabled to TransactionalMultiQuery. |
+| 3.1.2 | Added possibility to overwrite default decimal separator when using CSV or XML output. |


### PR DESCRIPTION
Added possibility to set decimal separator char manually. This is used in Oracle Decimal typed fields when returning data as CSV or XML.