### PR TITLE
Task uplift

### DIFF
--- a/Frends.Community.Oracle.Tests/Frends.Community.Oracle.Tests.csproj
+++ b/Frends.Community.Oracle.Tests/Frends.Community.Oracle.Tests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.35" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.180" />
-	<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.0.0" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.260" />
+	<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Frends.Community.Oracle/Frends.Community.Oracle.csproj
+++ b/Frends.Community.Oracle/Frends.Community.Oracle.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net471;net6.0;net8.0</TargetFrameworks>
     <Company>HiQ Finland</Company>
     <Description>Tasks for performing queries to Oracle database</Description>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -11,7 +11,7 @@
     <IncludeSource>true</IncludeSource>
     <PackageTags>Frends</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.2</Version>
+    <Version>3.3.0</Version>
 
   </PropertyGroup>
 
@@ -22,10 +22,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.35" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.180" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageReference Include="Dapper" Version="2.1.35" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.260" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -268,3 +268,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | 3.2.0 | Added possibility to overwrite default decimal separator in Decimal typed columns, when using CSV or XML output. Added property for setting DateTime output format. |
 | 3.2.1 | Updated Oracle.ManagedDataAccess.Client library and added functionality to replace invalid xml characters with underscore '_'. Fixed also workflows and changed them to be run on ubuntu. |
 | 3.2.2 | Added functionality to replace invalid xml characters with underscore '_' when using pivot sql query. |
+| 3.3.0 | Targeted to .NET6 and 8 and updated packages. |

--- a/_build/deploy_oracle_docker_container.sh
+++ b/_build/deploy_oracle_docker_container.sh
@@ -7,7 +7,7 @@ git clone https://github.com/oracle/docker-images.git ./_build/docker-images
 cd ./_build/docker-images/OracleDatabase/SingleInstance/dockerfiles
 ./buildContainerImage.sh -v 18.4.0 -x
 
-docker-compose -f ./../../../../../Frends.Community.Oracle.Tests/docker-compose.yml up -d
+docker compose -f ./../../../../../Frends.Community.Oracle.Tests/docker-compose.yml up -d
 
 echo 'waiting for container to ready up...'
 sleep 900


### PR DESCRIPTION
Targeted to .NET6 and 8 and updated packages. Removed hyphen from workflow docker compose command, as the usage of the command has been changed.